### PR TITLE
add result to operator

### DIFF
--- a/src/pages/settings.ts
+++ b/src/pages/settings.ts
@@ -144,6 +144,6 @@ class SettingsView extends DestructableView{
 
 
 if(wallet !== null && blockchainExplorer !== null)
-	new SettingsView('#app');
+	return new SettingsView('#app');
 else
 	window.location.href = '#index';


### PR DESCRIPTION
There is no good reason to create a new object to not do anything with it. Most of the time, this is due to a missing piece of code and so could lead to an unexpected behavior in production.

If it was done on purpose because the constructor has side-effects, then that side-effect code should be moved into a separate method and called directly.