### PR TITLE
Potential fix for code scanning alert no. 3876: Client-side cross-site scripting

### DIFF
--- a/src/lib/numbersLab/Router.ts
+++ b/src/lib/numbersLab/Router.ts
@@ -32,13 +32,13 @@ export class Router {
 	 * @returns {any}
 	 */
 	static extractPageFromUrl() {
+		let pageName = 'index';
 		if (window.location.hash.indexOf('#!') != -1) {
-			return window.location.hash.substr(2);
-		}else if (window.location.hash.indexOf('#') != -1) {
-			return window.location.hash.substr(1);
-		} else {
-			return 'index';
+			pageName = window.location.hash.substr(2);
+		} else if (window.location.hash.indexOf('#') != -1) {
+			pageName = window.location.hash.substr(1);
 		}
+		return encodeURIComponent(pageName);
 	}
 
 	changePageFromHash(){


### PR DESCRIPTION
Potential fix for [https://github.com/ConcealNetwork/conceal-web-wallet/security/code-scanning/3876](https://github.com/ConcealNetwork/conceal-web-wallet/security/code-scanning/3876)

To fix the problem, we need to sanitize the `window.location.hash` value before using it to construct the URL for loading JavaScript content. This can be done by encoding the URL components to ensure that any potentially malicious characters are neutralized.

1. Modify the `extractPageFromUrl` function in `src/lib/numbersLab/Router.ts` to sanitize the extracted page name.
2. Use a library like `encodeURIComponent` to encode the URL components properly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
