### PR TITLE
Potential fix for code scanning alert no. 3877: Unvalidated dynamic method call

### DIFF
--- a/src/lib/numbersLab/Router.ts
+++ b/src/lib/numbersLab/Router.ts
@@ -20,6 +20,8 @@ export class Router {
 
 	urlPrefix = '!';
 
+	allowedPages = ['index', 'home', 'about', 'contact']; // Add your allowed page names here
+
 	constructor(routerBaseHtmlRelativity  : string = './', routerBaseRelativity : string = '../') {
 		let self = this;
 		this.routerBaseHtmlRelativity = routerBaseHtmlRelativity;
@@ -102,16 +104,22 @@ export class Router {
 	injectNewPage(content: string, jsContentPath: string | null) {
 		$('#page').hide().html(content);
 		if (jsContentPath !== null) {
-			this.unloadRequirejs(jsContentPath);
-			this.unloadRequirejs(jsContentPath.replace(this.routerBaseJsRelativity, ''));
-			requirejs([jsContentPath], function (App) {
-				$('#page').show();
+			let pageName = jsContentPath.split('/').pop()?.replace('.js', '');
+			if (pageName && this.allowedPages.includes(pageName)) {
+				this.unloadRequirejs(jsContentPath);
+				this.unloadRequirejs(jsContentPath.replace(this.routerBaseJsRelativity, ''));
+				requirejs([jsContentPath], function (App) {
+					$('#page').show();
+					$('#pageLoading').hide();
+				}, function (err) {
+					//console.log(err);
+					$('#page').show();
+					$('#pageLoading').hide();
+				});
+			} else {
+				console.error('Invalid page name:', pageName);
 				$('#pageLoading').hide();
-			}, function (err) {
-				//console.log(err);
-				$('#page').show();
-				$('#pageLoading').hide();
-			});
+			}
 		}
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/ConcealNetwork/conceal-web-wallet/security/code-scanning/3877](https://github.com/ConcealNetwork/conceal-web-wallet/security/code-scanning/3877)

To fix the problem, we need to validate the `jsContentPath` before passing it to `requirejs`. This can be done by maintaining a whitelist of allowed page names and checking the extracted page name against this list. If the page name is not in the whitelist, we should handle it appropriately (e.g., by showing an error message or redirecting to a default page).

1. Create a whitelist of allowed page names.
2. Validate the extracted page name against the whitelist before using it in the `requirejs` call.
3. Update the `injectNewPage` method to include this validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
